### PR TITLE
feat: close project modal info on browser back

### DIFF
--- a/src/features/settings/components/project-info.tsx
+++ b/src/features/settings/components/project-info.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { ReactComponent as CrossIcon } from "src/assets/svg/close-outline.svg";
@@ -108,27 +108,41 @@ const ProjectInfoCloseButton = styled.button`
   right: 0;
 `;
 
+const LOCATION_HASH = "#about";
+
 export const ProjectInfo = () => {
   const lastCheckedDate = process.env.REACT_APP_LAST_CHECK_DATE
     ? new Date(Number(process.env.REACT_APP_LAST_CHECK_DATE))
     : undefined;
   const version = process.env.REACT_APP_COMMIT_REF;
 
-  const [isProjectInfoVisible, setIsProjectInfoVisible] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
 
-  const toggleVisibility = () => {
-    setIsProjectInfoVisible((v) => !v);
+  const isProjectInfoVisible = location.hash === LOCATION_HASH;
+
+  const show = () => {
+    navigate(LOCATION_HASH);
+  };
+
+  const hide = () => {
+    // TODO: add E2E tests: when URL with "#about" is opened in a new tab and close button is clicked, the modal should close
+    if (location.key === "default") {
+      navigate(location.pathname, { replace: true });
+    } else {
+      navigate(-1);
+    }
   };
 
   return isProjectInfoVisible ? (
     <ProjectInfoPositioner>
-      <Backdrop onClick={toggleVisibility} />
+      <Backdrop onClick={hide} />
       <ProjectInfoModal lastCheckDate={lastCheckedDate} version={version} />
-      <ProjectInfoCloseButton onClick={toggleVisibility}>
+      <ProjectInfoCloseButton onClick={hide}>
         <CrossIcon />
       </ProjectInfoCloseButton>
     </ProjectInfoPositioner>
   ) : (
-    <Button onClick={toggleVisibility}>Info</Button>
+    <Button onClick={show}>Info</Button>
   );
 };


### PR DESCRIPTION
Resolves #43

There are a couple of flows that had to be catered for:
1. Open modal -> click on close button -> modal should close
2. Open modal -> browser back -> modal should close
3. Copy URL to a new tab with the "#about" fragment -> modal should show
4. Copy URL to a new tab with the "#about" fragment -> click on close button -> modal should close

Essentially there are 2 areas which required changes:
- how to toggle the visibility of the modal
- what actions to perform when the modal is closed via the button or browser back

This approach relies on the presence of "#about" in the URL to determine if the modal should be shown. This is done by checking `location.hash`. Performing a browser back will omit the "#about" so the modal is automatically hidden.
(resolves 2, 3)

On pressing the close button, a back navigation is performed, so likewise, the modal is hidden correctly. This behaviour is useful  since you wouldn't want to push a new entry into the history stack as that would imply pressing back will open the modal again.
(resolves 1)

Now, 4 is tricky as navigating back just after opening a new tab will exit the app. To handle this, I checked if `location.key` is "default". If it's default, that means the user freshly navigated here. https://stackoverflow.com/a/70532858

---

Note that there's another scenario: "Copy URL to a new tab with the "#about" fragment -> browser back". However, this doesn't really make sense as the user would expect to exit the app rather than close the modal. So this case doesn't need to be handled.